### PR TITLE
More flexible support for triggering call of html function

### DIFF
--- a/syntaxes/lit-html.json
+++ b/syntaxes/lit-html.json
@@ -5,7 +5,7 @@
 		{
 			"name": "taggedTemplates",
 			"contentName": "meta.embedded.block.html",
-			"begin": "(?x)(\\s+?(?:html|raw)\\s*)(`)",
+			"begin": "(?x)(\\s+?(\\w+\\.)?(?:html|raw)\\s*)(`)",
 			"beginCaptures": {
 				"1": {
 					"name": "entity.name.function.tagged-template.js"

--- a/syntaxes/lit-html.json
+++ b/syntaxes/lit-html.json
@@ -5,7 +5,7 @@
 		{
 			"name": "taggedTemplates",
 			"contentName": "meta.embedded.block.html",
-			"begin": "(?x)(\\s+?(?:html|raw))(`)",
+			"begin": "(?x)(\\s+?(?:html|raw)\\s*)(`)",
 			"beginCaptures": {
 				"1": {
 					"name": "entity.name.function.tagged-template.js"


### PR DESCRIPTION
- support for whitespaces between `html` and the backticked string
- support for prefixes of `html` function. In example to make hyperHTML work as well