### PR TITLE
Relax template literal entry point

### DIFF
--- a/syntaxes/lit-html.json
+++ b/syntaxes/lit-html.json
@@ -15,7 +15,7 @@
 		{
 			"name": "string.js.taggedTemplate",
 			"contentName": "meta.embedded.block.html",
-			"begin": "(?x)(\\s+?(\\w+\\.)?(?:html|raw)\\s*)(`)",
+			"begin": "(?x)(\\s+?(\\w+\\.)?(?:html|raw|render)\\s*)?(`)(?=$|\\s*<[a-zA-Z!])",
 			"beginCaptures": {
 				"1": {
 					"name": "entity.name.function.tagged-template.js"


### PR DESCRIPTION
This project has everything it needs to be used as generic highlighter for HTML inside template literals but it's unfortunately fully coupled with `html` or `raw` keywords.

With the proposed RegExp, other projects using lit-html or not, will still benefit from this plugin without needing yet another fork, and could highlight HTML in every template string that contains some.

Thanks for considering this PR, also thanks for hints on how to improve it (I did not want to use `$|...` and force the followed by but for some reason that doesn't work in my vscode, no matter if I explicitly set new lines too)