### PR TITLE
Add support for svg template tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,21 @@
                 "embeddedLanguages": {
                     "meta.template.expression.ts": "typescript"
                 }
+            },
+            {
+                "injectTo": [
+                    "source.js",
+                    "source.js.jsx",
+                    "source.jsx",
+                    "source.ts",
+                    "source.tsx",
+                    "text.html.basic"
+                ],
+                "scopeName": "inline.lit-html-svg",
+                "path": "./syntaxes/lit-html-svg.json",
+                "embeddedLanguages": {
+                    "meta.embedded.block.xml": "xml"
+                }
             }
         ],
         "typescriptServerPlugins": [

--- a/syntaxes/lit-html-svg.json
+++ b/syntaxes/lit-html-svg.json
@@ -1,0 +1,51 @@
+{
+	"fileTypes": [],
+	"injectionSelector": "L:source.js -comment, L:source.jsx -comment, L:source.js.jsx -comment, L:source.ts -comment, L:source.tsx -comment",
+	"injections": {
+		"L:source": {
+			"patterns": [
+				{
+					"match": "<",
+					"name": "invalid.illegal.bad-angle-bracket.html"
+				}
+			]
+		}
+	},
+	"patterns": [
+		{
+			"name": "string.js.taggedTemplate.svg",
+			"contentName": "meta.embedded.block.svg",
+			"begin": "(?x)(\\s+?(\\w+\\.)?(?:svg)\\s*)(`)",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.name.function.tagged-template.js"
+				},
+				"2": {
+					"name": "string.js"
+				},
+				"3": {
+					"name": "punctuation.definition.string.template.begin.js"
+				}
+			},
+
+			"end": "(`)",
+			"endCaptures": {
+				"0": {
+					"name": "string.js"
+				},
+				"1": {
+					"name": "punctuation.definition.string.template.end.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "source.ts#template-substitution-element"
+				},
+				{
+					"include": "text.xml"
+				}
+			]
+		}
+	],
+	"scopeName": "inline.lit-html-svg"
+}


### PR DESCRIPTION
Per the comment in https://github.com/mjbvz/vscode-lit-html/pull/7#issuecomment-353220864, I implemented this into a separate scope to handle the language difference. Please note however that:

1. I couldn't find SVG-specific language support in the vscode repo, so I set the `embeddedLanguages` to `xml` within `grammars` in `package.json` given that SVG is XML-based to begin with.
2. Similarly within the added `lit-html-svg.json`, I set the `patterns` include to `text.xml` instead of `text.html.basic`.

With this patch, the end result highlighting for `svg` looks like the following:

![image](https://user-images.githubusercontent.com/643503/41176354-efe73868-6b14-11e8-9ce7-1db19e73fb6d.png)
