### PR TITLE
Fix #30 - Add support for a literal as a function argument

### DIFF
--- a/syntaxes/lit-html.json
+++ b/syntaxes/lit-html.json
@@ -15,7 +15,7 @@
 		{
 			"name": "string.js.taggedTemplate",
 			"contentName": "meta.embedded.block.html",
-			"begin": "(?x)(\\s+?(\\w+\\.)?(?:html|raw)\\s*)(`)",
+			"begin": "(?x)(\\s+?(\\w+\\.)|\\(?(?:html|raw)\\s*)(`)",
 			"beginCaptures": {
 				"1": {
 					"name": "entity.name.function.tagged-template.js"


### PR DESCRIPTION
support for ``funcname(html`...`)``