### PR TITLE
Add support for CSS as embedded lang

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
                 "scopeName": "inline.lit-html",
                 "path": "./syntaxes/lit-html.json",
                 "embeddedLanguages": {
-                    "meta.embedded.block.html": "html"
+                    "meta.embedded.block.html": "html",
+                    "meta.embedded.block.css": "css",
+                    "source.css": "css"
                 }
             },
             {


### PR DESCRIPTION
Adds `css` to `embeddedLanguages` allowing comment toggle to work. Resolves #33 

![output](https://user-images.githubusercontent.com/643503/42183196-bec04e7a-7df5-11e8-8058-62e5f4a1ca89.gif)
