### PR TITLE
highlight lit template inside javascript blocks appeared in PHP

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
                     "source.jsx",
                     "source.ts",
                     "source.tsx",
-                    "text.html.basic"
+                    "text.html.basic",
+                    "text.html.php"
                 ],
                 "scopeName": "inline.lit-html",
                 "path": "./syntaxes/lit-html.json",


### PR DESCRIPTION
Sometimes we may need to embed React/Preact to existing traditional projects not written mainly in js/ts, this patch will allow lit-template syntax highlighting inside the script tags in PHP files.

![Before(left) and after(right) the patch](https://user-images.githubusercontent.com/10095765/145151046-2d0fabf6-097d-4337-964a-f2387519ac6e.png)

